### PR TITLE
add buttons to check or uncheck all selected chapters

### DIFF
--- a/abogen/book_handler.py
+++ b/abogen/book_handler.py
@@ -1355,6 +1355,15 @@ class HandlerDialog(QDialog):
         select_layout.addWidget(self.deselect_all_btn)
         buttons_layout.addLayout(select_layout)
 
+        enable_disable_layout = QHBoxLayout()
+        self.check_selected_btn = QPushButton("Check selected", self)
+        self.check_selected_btn.clicked.connect(self.check_selected_items)
+        self.uncheck_selected_btn = QPushButton("Uncheck selected", self)
+        self.uncheck_selected_btn.clicked.connect(self.uncheck_selected_items)
+        enable_disable_layout.addWidget(self.check_selected_btn)
+        enable_disable_layout.addWidget(self.uncheck_selected_btn)
+        buttons_layout.addLayout(enable_disable_layout)
+
         parent_layout = QHBoxLayout()
         self.select_parents_btn = QPushButton("Select parents", self)
         self.select_parents_btn.clicked.connect(self.select_parent_chapters)


### PR DESCRIPTION
I usually split big books into smaller parts (because my phone doesn’t have much storage), so I only need to generate audio for specific sections. When a book has like 100 chapters, manually clicking through each one gets old fast.

Added two new buttons in the layout:

Check selected => calls check_selected_items() on selected chapters in the view
Uncheck selected => calls uncheck_selected_items() on selected chapters in the view

This is mainly a QoL addition for a specific case like mine, but it could help others too.