### PR TITLE
Add `Line` option for subtitle generation

### DIFF
--- a/abogen/conversion.py
+++ b/abogen/conversion.py
@@ -1246,9 +1246,14 @@ class ConversionThread(QThread):
                 if end is None or end <= start or end <= 0:
                     subtitle_entries[-1] = (start, fallback_end_time, text)
 
-        elif self.subtitle_mode == "Sentence" or self.subtitle_mode == "Sentence + Comma":
+        elif self.subtitle_mode in ["Sentence", "Sentence + Comma", "Line"]:
             # Define separator pattern based on mode
-            separator = r"[.!?]" if self.subtitle_mode == "Sentence" else r"[.!?,]"
+            if self.subtitle_mode == "Line":
+                separator = r"\n"
+            elif self.subtitle_mode == "Sentence":
+                separator = r"[.!?]"
+            else:  # Sentence + Comma
+                separator = r"[.!?,]"
             current_sentence = []
             word_count = 0
 

--- a/abogen/gui.py
+++ b/abogen/gui.py
@@ -953,6 +953,7 @@ class abogen(QWidget):
         self.subtitle_combo.setToolTip(
             "Choose how subtitles will be generated:\n"
             "Disabled: No subtitles will be generated.\n"
+            "Line: Subtitles will be generated for each line.\n"
             "Sentence: Subtitles will be generated for each sentence.\n"
             "Sentence + Comma: Subtitles will be generated for each sentence and comma.\n"
             "Sentence + Highlighting: Subtitles with word-by-word karaoke highlighting.\n"
@@ -963,7 +964,7 @@ class abogen(QWidget):
                 for lang in SUPPORTED_LANGUAGES_FOR_SUBTITLE_GENERATION
             )
         )
-        subtitle_options = ["Disabled", "Sentence", "Sentence + Comma", "Sentence + Highlighting"] + [
+        subtitle_options = ["Disabled", "Line", "Sentence", "Sentence + Comma", "Sentence + Highlighting"] + [
             f"{i} word" if i == 1 else f"{i} words" for i in range(1, 11)
         ]
         self.subtitle_combo.addItems(subtitle_options)


### PR DESCRIPTION
If one already has a text nicely broken into phrases by line-endings and does not want any further analysis for choosing what to include into a subtitle any of existing options for subtitle generation do not work.  
For example, `Mr. and Mrs. Smith` would be split into three subtitles when choosing "Sentence" option.  

This PR aims to solve this by adding new "Line" option for subtitle generation.

<img width="554" height="173" alt="image" src="https://github.com/user-attachments/assets/4d01263d-cfb7-4082-9c10-86913e824822" />
