### PR TITLE
Ensure appropriate speech pauses by adding newlines at epub processing

### DIFF
--- a/abogen/book_parser.py
+++ b/abogen/book_parser.py
@@ -915,7 +915,11 @@ class EpubParser(BaseBookParser):
 
             if slice_html.strip():
                 slice_soup = BeautifulSoup(slice_html, "html.parser")
-                for tag in slice_soup.find_all(["p", "div"]):
+
+                # Add line breaks after block-level elements to ensure pauses in speech
+                for tag in slice_soup.find_all(
+                    ["p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "blockquote"]
+                ):
                     tag.append("\n\n")
 
                 for ol in slice_soup.find_all("ol"):

--- a/abogen/text_extractor.py
+++ b/abogen/text_extractor.py
@@ -1023,8 +1023,13 @@ class EpubExtractor:
         if not html:
             return ""
         soup = BeautifulSoup(html, "html.parser")
-        for tag in soup.find_all(["p", "div"]):
+
+        # Add line breaks after block-level elements to ensure pauses in speech
+        for tag in soup.find_all(
+            ["p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "blockquote"]
+        ):
             tag.append("\n\n")
+
         for ol in soup.find_all("ol"):
             start_attr = ol.get("start")
             try:


### PR DESCRIPTION
This change expands the list of tags that get newlines inserted after them at preprocessing.

Before this change, text like:

```
Section heading

First sentence of the section. ...
```

Would have been mashed into one spoken sentence like:

```
Section heading first sentence of the section. ...
```

Tested on one non-fiction epub that is peppered with text sections, side sections, quotes and tables.