### PR TITLE
Fix OPUS encoding bitrate: 24kbps → 128kbps

### DIFF
--- a/abogen/pyqt/conversion.py
+++ b/abogen/pyqt/conversion.py
@@ -835,7 +835,7 @@ class ConversionThread(QThread):
                         "-i",
                         "pipe:0",
                     ]
-                    cmd.extend(["-c:a", "libopus", "-b:a", "24000"])
+                    cmd.extend(["-c:a", "libopus", "-b:a", "128000"])
                     cmd.append(merged_out_path)
                     ffmpeg_proc = create_process(cmd, stdin=subprocess.PIPE, text=False)
                     merged_out_file = None
@@ -990,7 +990,7 @@ class ConversionThread(QThread):
                             "-i",
                             "pipe:0",
                         ]
-                        cmd.extend(["-c:a", "libopus", "-b:a", "24000"])
+                        cmd.extend(["-c:a", "libopus", "-b:a", "128000"])
                         cmd.append(chapter_out_path)
                         chapter_ffmpeg_proc = create_process(
                             cmd, stdin=subprocess.PIPE, text=False
@@ -1656,7 +1656,7 @@ class ConversionThread(QThread):
                     )
                     cmd.extend(metadata_options)
                 elif self.output_format == "opus":
-                    cmd.extend(["-c:a", "libopus", "-b:a", "24000"])
+                    cmd.extend(["-c:a", "libopus", "-b:a", "128000"])
                 else:
                     self.log_updated.emit(
                         (f"Unsupported output format: {self.output_format}", "red")

--- a/abogen/webui/conversion_runner.py
+++ b/abogen/webui/conversion_runner.py
@@ -2595,7 +2595,7 @@ def _build_ffmpeg_command(path: Path, fmt: str, metadata: Optional[Dict[str, str
     if fmt == "mp3":
         base += ["-c:a", "libmp3lame", "-qscale:a", "2"]
     elif fmt == "opus":
-        base += ["-c:a", "libopus", "-b:a", "24000"]
+        base += ["-c:a", "libopus", "-b:a", "128000"]
     elif fmt == "m4b":
         base += ["-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart+use_metadata_tags"]
     else:


### PR DESCRIPTION
## Summary

- OPUS audio bitrate was set to `24000` (24kbps) in all ffmpeg encoding calls — this appears to confuse the audio sample rate (24000 Hz) with the target bitrate
- Result: extremely low quality, muffled/robotic audio when outputting OPUS format
- Fix: changed to `128000` (128kbps), appropriate for speech/audiobook content

## Files changed

- `abogen/pyqt/conversion.py` — 3 occurrences (merged output, chapter output, subtitle file output)
- `abogen/webui/conversion_runner.py` — 1 occurrence

## Test plan

- [x] Generate OPUS audio via desktop GUI — verify clear output at 128kbps
- [x] Generate OPUS audio via web UI — verify same
- [ ] Confirm file sizes are reasonable (~1MB/min for speech at 128kbps)

🤖 Generated with [Claude Code](https://claude.ai/code)