### PR TITLE
feat: Add TTSBackendMetadata model

### DIFF
--- a/abogen/tts_backend.py
+++ b/abogen/tts_backend.py
@@ -1,10 +1,28 @@
 """
 TTS Backend Interface
 
-This module defines the protocol for TTS backends.
+This module defines the protocol for TTS backends and the
+metadata model that describes a backend implementation.
 """
 
+from dataclasses import dataclass
 from typing import Protocol, List, Dict, Any
+
+
+@dataclass(frozen=True)
+class TTSBackendMetadata:
+    """
+    Immutable metadata describing a TTS backend implementation.
+
+    Attributes:
+        id: Unique backend identifier (e.g. ``"kokoro"``, ``"supertonic"``).
+        name: Human-readable display name.
+        description: Short description of the backend.
+    """
+
+    id: str
+    name: str
+    description: str
 
 
 class TTSBackend(Protocol):
@@ -14,6 +32,10 @@ class TTSBackend(Protocol):
     All TTS backends must implement this interface to be compatible
     with the application.
     """
+
+    @property
+    def metadata(self) -> TTSBackendMetadata:
+        ...
 
     def __init__(self, **kwargs) -> None:
         """

--- a/tests/test_tts_backend.py
+++ b/tests/test_tts_backend.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+from abogen.tts_backend import TTSBackendMetadata
+
+
+class TestTTSBackendMetadata:
+    def test_is_frozen_dataclass(self):
+        assert dataclass(TTSBackendMetadata)
+
+    def test_fields_are_present(self):
+        meta = TTSBackendMetadata(
+            id="test",
+            name="Test Backend",
+            description="A test backend",
+        )
+        assert meta.id == "test"
+        assert meta.name == "Test Backend"
+        assert meta.description == "A test backend"
+
+    def test_is_immutable(self):
+        import pytest
+
+        meta = TTSBackendMetadata(
+            id="kokoro",
+            name="Kokoro",
+            description="Test",
+        )
+        with pytest.raises(Exception):
+            meta.id = "changed"


### PR DESCRIPTION
## Summary

This PR introduces `TTSBackendMetadata`, a lightweight immutable data model describing TTS backend capabilities.

### Changes

- Add the `TTSBackendMetadata` dataclass.
- Associate metadata with TTS backend implementations.
- Define a common structure for backend identification and descriptive information.
- Add tests covering the metadata model.

### Motivation

As the project moves toward a modular backend architecture, each backend should expose a consistent set of metadata independent of its implementation.

Introducing a dedicated metadata model provides a stable foundation for future work such as:

- backend registration;
- backend discovery;
- backend selection in the UI;
- capability reporting.

### Notes

This PR does not change runtime behavior.
It only introduces the shared metadata model that will be used by follow-up architectural refactoring.