### PR TITLE
Preserve user-entered book metadata after extraction

### DIFF
--- a/abogen/webui/routes/utils/form.py
+++ b/abogen/webui/routes/utils/form.py
@@ -826,6 +826,8 @@ def build_pending_job_from_extraction(
         analysis_requested=initial_analysis,
     )
 
+    apply_book_step_form(pending, form, settings=settings, profiles=profiles_map)
+
     return PendingBuildResult(
         pending=pending,
         selected_speaker_config=selected_speaker_config or None,

--- a/tests/test_pending_job_metadata.py
+++ b/tests/test_pending_job_metadata.py
@@ -1,0 +1,40 @@
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+routes_package = types.ModuleType("abogen.webui.routes")
+routes_package.__path__ = [
+    str(Path(__file__).parents[1] / "abogen" / "webui" / "routes")
+]
+sys.modules["abogen.webui.routes"] = routes_package
+
+from abogen.webui.routes.utils.form import (  # noqa: E402
+    build_pending_job_from_extraction,
+    load_settings,
+)
+
+
+def test_user_metadata_overrides_extraction_fallback(tmp_path: Path) -> None:
+    extraction = SimpleNamespace(
+        chapters=[SimpleNamespace(title="Chapter 1", text="Text")],
+        metadata={"title": "423d828962c34d2b8a53bbe91176305a"},
+        cover_image=None,
+        cover_mime=None,
+        total_characters=4,
+        combined_text="Text",
+    )
+
+    result = build_pending_job_from_extraction(
+        stored_path=tmp_path / "book.txt",
+        original_name="book.txt",
+        extraction=extraction,
+        form={"meta_title": "My Book", "meta_author": "Ada Author"},
+        settings=load_settings(),
+        profiles={},
+    )
+
+    assert result.pending.metadata_tags["title"] == "My Book"
+    assert result.pending.metadata_tags["author"] == "Ada Author"
+    assert result.pending.metadata_tags["authors"] == "Ada Author"


### PR DESCRIPTION
User-entered title and author fields were discarded when a new upload built its pending job from extracted fallback metadata. Apply the submitted book form after extraction so explicit metadata wins, with a regression covering the fallback hash case.

Fixes #150
